### PR TITLE
ajuste texto about

### DIFF
--- a/subpages/about.html
+++ b/subpages/about.html
@@ -22,7 +22,7 @@
                 </div>
                 <div class="col-text">
                     <h4>Casiopea</h4>
-                    <p>Casiopea es un colectivo mexicano fundado en el 2013 por Alexandra Castellanos, Ana Cruz, Andrea Mondragón y Sandra Medina. Su trabajo está enfocado en la producción de animación, diseño e ilustración a través de la mezcla de técnicas análogas y digitales. Dedicadas principalmente a la difusión de contenido cultural, así como la creación de cortometrajes independientes, propiedad </p>
+                    <p>Casiopea es un colectivo mexicano fundado por Alexandra Castellanos, Ana Cruz, Andrea Mondragón y Sandra Medina en el 2013. Se dedican a la producción de animación, ilustración y propiedad intelectual orientada hacia la difusión de contenido cultural, académico y experimental a través de una particular mezcla de técnicas digitales y análogas. </p>
                     <ul class="team-social-list">
                         <li class="weeeb"><a href="https://www.casiopea.mx" target="_blank"><i>casiopea.mx</i></a></li>
                         <li><a href="https://vimeo.com/casiopea" target="_blank"><i><img loading="auto"src="assets/images/iconos/icos/icons8-vimeo-100.png" alt="vimeo"></i></a></li>


### PR DESCRIPTION
Casiopea es un colectivo mexicano fundado por Alexandra Castellanos, Ana Cruz, Andrea Mondragón y Sandra Medina en el 2013. Se dedican a la producción de animación, ilustración y propiedad intelectual orientada hacia la difusión de contenido cultural, académico y experimental a través de una particular mezcla de técnicas digitales y análogas.